### PR TITLE
Add switch input action to tray menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # DDCSwitchInput
 
-Switch input device on windows
+Switch display input from the Windows system tray.
+
+Use the tray icon menu to choose a monitor and input source. Double-click the icon or select **Switch now** to apply the change.
 
 ## Additional notes
 

--- a/src/TrayApp.cs
+++ b/src/TrayApp.cs
@@ -104,8 +104,11 @@ namespace DdcTraySwitcher
                 Checked = AutoStart.IsRegistered()
             };
 
+            var switchItem = new ToolStripMenuItem("Switch now", null, (s, e) => ApplySelectedInput());
+
             menu.Items.Add(monitorMenu);
             menu.Items.Add(inputMenu);
+            menu.Items.Add(switchItem);
             menu.Items.Add(new ToolStripSeparator());
             menu.Items.Add(autostartItem);
             menu.Items.Add(new ToolStripMenuItem("Quit", null, (s, e) => Exit()));
@@ -131,16 +134,13 @@ namespace DdcTraySwitcher
             }
         }
 
-        private void OnClick(object sender, MouseEventArgs e)
+        private void ApplySelectedInput()
         {
-            if (e.Button == MouseButtons.Left && e.Clicks == 2)
+            bool result = MonitorHelper.SetInput(selectedMonitor, selectedInput);
+            if (!result)
             {
-                bool result = MonitorHelper.SetInput(selectedMonitor, selectedInput);
-                if (!result)
-                {
-                    MessageBox.Show($"Input could not be set!\nMonitor: {selectedMonitor}, Input: 0x{selectedInput:X}", 
-                        "Fehler", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
+                MessageBox.Show($"Input could not be set!\nMonitor: {selectedMonitor}, Input: 0x{selectedInput:X}",
+                    "DDC error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -148,12 +148,7 @@ namespace DdcTraySwitcher
         {
             if (e.Button == MouseButtons.Left)
             {
-                bool result = MonitorHelper.SetInput(selectedMonitor, selectedInput);
-                if (!result)
-                {
-                    MessageBox.Show($"Input could not be set!\nMonitor: {selectedMonitor}, Input: 0x{selectedInput:X}", 
-                        "Fehler", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
+                ApplySelectedInput();
             }
         }
 


### PR DESCRIPTION
## Summary
- add "Switch now" menu item for quick input switching
- centralize monitor input switching logic
- document menu usage

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2486292083278e99bc2fd1f9e49b